### PR TITLE
Create fuel-toolchain.toml

### DIFF
--- a/contract/fuel-toolchain.toml
+++ b/contract/fuel-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+
+channel = "beta-3"


### PR DESCRIPTION
added the `fuel-toolchain.toml` with beta-3 that automatically overrides local installations of the fuel toolchain dependencies.